### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-nice-river-08f17380f.yml
+++ b/.github/workflows/azure-static-web-apps-nice-river-08f17380f.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  pull-requests: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/BlairLeduc/scanreader/security/code-scanning/2](https://github.com/BlairLeduc/scanreader/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the jobs. Based on the workflow's functionality:
1. The `build_and_deploy_job` requires `contents: read` to access the repository contents and `pages: write` to deploy the static web app.
2. The `close_pull_request_job` requires `contents: read` and possibly `pull-requests: write` to close pull requests.

We will add the `permissions` block to the root of the workflow to apply these permissions globally, as both jobs require similar permissions. If the jobs had significantly different permission requirements, we would define job-specific `permissions` blocks instead.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
